### PR TITLE
XOUT-14538 Anhebung der Untertow-Version auf 2.3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
         <version.commons-cli>1.4</version.commons-cli>
         <version.commons-lang3>3.12.0</version.commons-lang3>
         <version.io.smallrye.jandex>3.0.3</version.io.smallrye.jandex>
-        <version.io.undertow>2.3.0.Final</version.io.undertow>
+        <version.io.undertow>2.3.5.Final</version.io.undertow>
         <version.jakarta.json.jakarta-json-api>2.1.1</version.jakarta.json.jakarta-json-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.authentication.jakarta-authentication-api>3.0.0</version.jakarta.authentication.jakarta-authentication-api>


### PR DESCRIPTION
https://ib.data-experts.de/browse/XOUT-14538